### PR TITLE
Introduce lttng based tracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,19 @@ jobs:
       - name: show-kernel-log
         run: sudo dmesg -c
 
+  test-lttng:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: prepare-development-libraries
+        run: sudo apt-get install lttng-tools lttng-modules-dkms liblttng-ust-dev
+      - name: make-lttng-builtin
+        run: |
+          make distclean
+          make -j4 USE_LTTNG=yes
+      - name: test
+        run: ./runtest --verbose --tags -slow --dump-logs
+
   build-debian-old:
     runs-on: ubuntu-latest
     container: debian:buster

--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -104,6 +104,13 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/lua/function_lua.c
     ${CMAKE_SOURCE_DIR}/src/lua/engine_lua.c
     ${CMAKE_SOURCE_DIR}/src/lua/debug_lua.c
+    ${CMAKE_SOURCE_DIR}/src/trace/trace.c
+    ${CMAKE_SOURCE_DIR}/src/trace/trace_aof.c
+    ${CMAKE_SOURCE_DIR}/src/trace/trace_commands.c
+    ${CMAKE_SOURCE_DIR}/src/trace/trace_db.c
+    ${CMAKE_SOURCE_DIR}/src/trace/trace_cluster.c
+    ${CMAKE_SOURCE_DIR}/src/trace/trace_server.c
+    ${CMAKE_SOURCE_DIR}/src/trace/trace_sys.c
     ${CMAKE_SOURCE_DIR}/src/commands.c
     ${CMAKE_SOURCE_DIR}/src/strl.c
     ${CMAKE_SOURCE_DIR}/src/connection.c

--- a/src/.clang-format-ignore
+++ b/src/.clang-format-ignore
@@ -14,3 +14,4 @@ sha1.*
 sha256.*
 siphash.c
 strl.c
+trace/trace_*

--- a/src/Makefile
+++ b/src/Makefile
@@ -295,6 +295,11 @@ ifeq ($(MALLOC),jemalloc)
 	FINAL_LIBS := ../deps/jemalloc/lib/libjemalloc.a $(FINAL_LIBS)
 endif
 
+ifeq ($(USE_LTTNG),yes)
+	FINAL_CFLAGS+=-DUSE_LTTNG
+	FINAL_LIBS += -llttng-ust
+endif
+
 # LIBSSL & LIBCRYPTO
 LIBSSL_LIBS=
 LIBSSL_PKGCONFIG := $(shell $(PKG_CONFIG) --exists libssl && echo $$?)
@@ -385,7 +390,7 @@ else
 	MAYBE_UNINSTALL_REDIS_SYMLINK=
 endif
 
-SERVER_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)
+SERVER_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS) -I.
 SERVER_AR=$(QUIET_AR)$(AR)
 SERVER_LD=$(QUIET_LINK)$(CC) $(FINAL_LDFLAGS)
 ENGINE_INSTALL=$(QUIET_INSTALL)$(INSTALL)
@@ -416,7 +421,9 @@ endif
 ENGINE_NAME=valkey
 SERVER_NAME=$(ENGINE_NAME)-server$(PROG_SUFFIX)
 ENGINE_SENTINEL_NAME=$(ENGINE_NAME)-sentinel$(PROG_SUFFIX)
+ENGINE_TRACE_OBJ=trace/trace.o trace/trace_db.o trace/trace_commands.o trace/trace_db.o trace/trace_sys.o trace/trace_cluster.o trace/trace_server.o trace/trace_aof.o
 ENGINE_SERVER_OBJ=threads_mngr.o adlist.o quicklist.o ae.o anet.o dict.o hashtable.o kvstore.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o memory_prefetch.o io_threads.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o cluster_legacy.o cluster_slot_stats.o crc16.o endianconv.o commandlog.o eval.o bio.o rio.o rand.o memtest.o syscheck.o crcspeed.o crccombine.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o valkey-check-rdb.o valkey-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o allocator_defrag.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o socket.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o resp_parser.o call_reply.o script.o functions.o commands.o strl.o connection.o unix.o logreqres.o rdma.o scripting_engine.o lua/script_lua.o lua/function_lua.o lua/engine_lua.o lua/debug_lua.o
+ENGINE_SERVER_OBJ+=$(ENGINE_TRACE_OBJ)
 ENGINE_CLI_NAME=$(ENGINE_NAME)-cli$(PROG_SUFFIX)
 ENGINE_CLI_OBJ=anet.o adlist.o dict.o valkey-cli.o zmalloc.o release.o ae.o serverassert.o crcspeed.o crccombine.o crc64.o siphash.o crc16.o monotonic.o cli_common.o mt19937-64.o strl.o cli_commands.o
 ENGINE_BENCHMARK_NAME=$(ENGINE_NAME)-benchmark$(PROG_SUFFIX)
@@ -540,6 +547,9 @@ DEP = $(ENGINE_SERVER_OBJ:%.o=%.d) $(ENGINE_CLI_OBJ:%.o=%.d) $(ENGINE_BENCHMARK_
 lua/%.o: lua/%.c .make-prerequisites
 	$(SERVER_CC) -MMD -o $@ -c $<
 
+trace/%.o: trace/%.c .make-prerequisites
+	$(SERVER_CC) -Itrace -MMD -o $@ -c $<
+
 unit/%.o: unit/%.c .make-prerequisites
 	$(SERVER_CC) -MMD -o $@ -c $<
 
@@ -563,7 +573,7 @@ endif
 commands.c: $(COMMANDS_DEF_FILENAME).def
 
 clean:
-	rm -rf $(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(ENGINE_UNIT_TESTS) $(ENGINE_LIB_NAME) unit/*.o unit/*.d lua/*.o lua/*.d *.o *.gcda *.gcno *.gcov valkey.info lcov-html Makefile.dep *.so
+	rm -rf $(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(ENGINE_UNIT_TESTS) $(ENGINE_LIB_NAME) unit/*.o unit/*.d lua/*.o lua/*.d trace/*.o trace/*.d *.o *.gcda *.gcno *.gcov valkey.info lcov-html Makefile.dep *.so
 	rm -f $(DEP)
 
 .PHONY: clean

--- a/src/aof.c
+++ b/src/aof.c
@@ -1129,12 +1129,16 @@ void flushAppendOnlyFile(int force) {
      * useful for graphing / monitoring purposes. */
     if (sync_in_progress) {
         latencyAddSampleIfNeeded("aof-write-pending-fsync", latency);
+        latencyTraceIfNeeded(aof, "aof-write-pending-fsync", latency);
     } else if (hasActiveChildProcess()) {
         latencyAddSampleIfNeeded("aof-write-active-child", latency);
+        latencyTraceIfNeeded(aof, "aof-write-active-child", latency);
     } else {
         latencyAddSampleIfNeeded("aof-write-alone", latency);
+        latencyTraceIfNeeded(aof, "aof-write-alone", latency);
     }
     latencyAddSampleIfNeeded("aof-write", latency);
+    latencyTraceIfNeeded(aof, "aof-write", latency);
 
     /* We performed the write so reset the postponed flush sentinel to zero. */
     server.aof_flush_postponed_start = 0;
@@ -1248,6 +1252,8 @@ try_fsync:
         }
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("aof-fsync-always", latency);
+        latencyTraceIfNeeded(aof, "aof-fsync-always", latency);
+
         server.aof_last_incr_fsync_offset = server.aof_last_incr_size;
         server.aof_last_fsync = server.mstime;
         atomic_store_explicit(&server.fsynced_reploff_pending, server.primary_repl_offset, memory_order_relaxed);
@@ -2501,6 +2507,7 @@ off_t getAppendOnlyFileSize(sds filename, int *status) {
     }
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("aof-fstat", latency);
+    latencyTraceIfNeeded(aof, "aof-fstat", latency);
     sdsfree(aof_filepath);
     return size;
 }
@@ -2577,6 +2584,7 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
         }
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("aof-rename", latency);
+        latencyTraceIfNeeded(aof, "aof-rename", latency);
         serverLog(LL_NOTICE, "Successfully renamed the temporary AOF base file %s into %s", tmpfile, new_base_filename);
 
         /* Rename the temporary incr aof file to 'new_incr_filename'. */
@@ -2603,6 +2611,7 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
             }
             latencyEndMonitor(latency);
             latencyAddSampleIfNeeded("aof-rename", latency);
+            latencyTraceIfNeeded(aof, "aof-rename", latency);
             serverLog(LL_NOTICE, "Successfully renamed the temporary AOF incr file %s into %s", temp_incr_aof_name,
                       new_incr_filename);
             sdsfree(temp_incr_filepath);

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -148,7 +148,8 @@ void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int failed_
     commandlogPushCurrentCommand(c, c->lastcmd);
     c->duration = 0;
     /* Log the reply duration event. */
-    latencyAddSampleIfNeeded("command-unblocking", reply_us / 1000);
+    latencyAddSampleIfNeeded("command-unblocking", reply_us);
+    latencyTraceIfNeeded(server, "command-unblocking", reply_us);
 }
 
 /* This function is called in the beforeSleep() function of the event loop

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -860,7 +860,7 @@ int clusterSaveConfig(int do_fsync) {
     }
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("cluster-config-open", latency);
-
+    latencyTraceIfNeeded(cluster, "cluster-config-open", latency);
     latencyStartMonitor(latency);
     while (offset < content_size) {
         written_bytes = write(fd, ci + offset, content_size - offset);
@@ -874,7 +874,7 @@ int clusterSaveConfig(int do_fsync) {
     }
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("cluster-config-write", latency);
-
+    latencyTraceIfNeeded(cluster, "cluster-config-write", latency);
     if (do_fsync) {
         latencyStartMonitor(latency);
         server.cluster->todo_before_sleep &= ~CLUSTER_TODO_FSYNC_CONFIG;
@@ -884,6 +884,7 @@ int clusterSaveConfig(int do_fsync) {
         }
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("cluster-config-fsync", latency);
+        latencyTraceIfNeeded(cluster, "cluster-config-fsync", latency);
     }
 
     latencyStartMonitor(latency);
@@ -893,7 +894,7 @@ int clusterSaveConfig(int do_fsync) {
     }
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("cluster-config-rename", latency);
-
+    latencyTraceIfNeeded(cluster, "cluster-config-rename", latency);
     if (do_fsync) {
         latencyStartMonitor(latency);
         if (fsyncFileDir(server.cluster_configfile) == -1) {
@@ -902,6 +903,7 @@ int clusterSaveConfig(int do_fsync) {
         }
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("cluster-config-dir-fsync", latency);
+        latencyTraceIfNeeded(cluster, "cluster-config-dir-fsync", latency);
     }
     retval = C_OK; /* If we reached this point, everything is fine. */
 
@@ -911,12 +913,14 @@ cleanup:
         close(fd);
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("cluster-config-close", latency);
+        latencyTraceIfNeeded(cluster, "cluster-config-close", latency);
     }
     if (retval == C_ERR) {
         latencyStartMonitor(latency);
         unlink(tmpfilename);
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("cluster-config-unlink", latency);
+        latencyTraceIfNeeded(cluster, "cluster-config-unlink", latency);
     }
     sdsfree(tmpfilename);
     sdsfree(ci);

--- a/src/config.c
+++ b/src/config.c
@@ -3150,6 +3150,57 @@ static int applyClientMaxMemoryUsage(const char **err) {
     return 1;
 }
 
+static int setTraceEvents(standardConfig *config, sds *argv, int argc, const char **err) {
+    UNUSED(config);
+
+    struct valkeyTraceEvents events = {0};
+    for (int i = 0; i < argc; i++) {
+        if (!strcasecmp(argv[i], "aof")) {
+            events.aof = 1;
+        } else if (!strcasecmp(argv[i], "server")) {
+            events.server = 1;
+        } else if (!strcasecmp(argv[i], "cluster")) {
+            events.cluster = 1;
+        } else if (!strcasecmp(argv[i], "sys")) {
+            events.sys = 1;
+        } else if (!strcasecmp(argv[i], "db")) {
+            events.db = 1;
+        } else if (!strcasecmp(argv[i], "commands")) {
+            events.commands = 1;
+        } else {
+            *err = "trace events should between [server,aof,cluster,sys,db,commands]";
+            goto configerr;
+        }
+    }
+    trace_events = events;
+    sdsclear(server.trace_events);
+    for (int i = 0; i < argc; i++) {
+        server.trace_events = sdscatprintf(server.trace_events, "%s", argv[i]);
+        if (i != argc - 1) {
+            server.trace_events = sdscatlen(server.trace_events, " ", 1);
+        }
+    }
+    return 1;
+configerr:
+    return 0;
+}
+
+static sds getTraceEvents(standardConfig *config) {
+    UNUSED(config);
+    return sdsdup(server.trace_events);
+}
+
+void rewriteTraceEvents(standardConfig *config,
+                        const char *name,
+                        struct rewriteConfigState *state) {
+    UNUSED(config);
+    if (sdslen(server.trace_events) == 0) {
+        rewriteConfigMarkAsProcessed(state, name);
+        return;
+    }
+    rewriteConfigRewriteLine(state, name, sdsdup(server.trace_events), 1);
+}
+
 standardConfig static_configs[] = {
     /* Bool configs */
     createBoolConfig("rdbchecksum", NULL, IMMUTABLE_CONFIG, server.rdb_checksum, 1, NULL, NULL),
@@ -3394,6 +3445,7 @@ standardConfig static_configs[] = {
     createSpecialConfig("rdma-bind", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigRdmaBindOption, getConfigRdmaBindOption, rewriteConfigRdmaBindOption, applyRdmaBind),
     createSpecialConfig("replicaof", "slaveof", IMMUTABLE_CONFIG | MULTI_ARG_CONFIG, setConfigReplicaOfOption, getConfigReplicaOfOption, rewriteConfigReplicaOfOption, NULL),
     createSpecialConfig("latency-tracking-info-percentiles", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigLatencyTrackingInfoPercentilesOutputOption, getConfigLatencyTrackingInfoPercentilesOutputOption, rewriteConfigLatencyTrackingInfoPercentilesOutputOption, NULL),
+    createSpecialConfig("trace-events", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setTraceEvents, getTraceEvents, rewriteTraceEvents, NULL),
 
     /* NULL Terminator, this is dropped when we convert to the runtime array. */
     {NULL},

--- a/src/connection.h
+++ b/src/connection.h
@@ -144,7 +144,8 @@ struct connection {
     ConnectionCallbackFunc conn_handler;
     ConnectionCallbackFunc write_handler;
     ConnectionCallbackFunc read_handler;
-    char *fmtname;
+    char *saddr;
+    char *daddr;
 };
 
 #define CONFIG_BINDADDR_MAX 16
@@ -273,9 +274,13 @@ static inline void connShutdown(connection *conn) {
 }
 
 static inline void connClose(connection *conn) {
-    if (conn->fmtname) {
-        free(conn->fmtname);
-        conn->fmtname = NULL;
+    if (conn->saddr) {
+        free(conn->saddr);
+        conn->saddr = NULL;
+    }
+    if (conn->daddr) {
+        free(conn->daddr);
+        conn->daddr = NULL;
     }
     conn->type->close(conn);
 }
@@ -344,20 +349,25 @@ static inline int connAddrSockName(connection *conn, char *ip, size_t ip_len, in
     return connAddr(conn, ip, ip_len, port, 0);
 }
 
-/* build a generic name for a connection of schema "LADDR:LPORT-RADDR:RPORT", except Unix socket */
+/* Format the connection address and store the result in daddr/saddr, except Unix socket */
 static inline int connFmtName(connection *conn) {
-    char fmtname[NET_ADDR_STR_LEN + NET_ADDR_STR_LEN + 2] = {0};
-    char laddr[NET_ADDR_STR_LEN], raddr[NET_ADDR_STR_LEN];
+    char addr[NET_ADDR_STR_LEN];
     int ret;
 
-    ret = connFormatAddr(conn, laddr, sizeof(laddr), 0);
-    if (ret < 0) return ret;
+    ret = connFormatAddr(conn, addr, sizeof(addr), 0);
+    if (ret) {
+        conn->daddr = strdup(addr);
+    } else {
+        conn->daddr = NULL;
+    }
 
-    ret = connFormatAddr(conn, raddr, sizeof(raddr), 1);
-    if (ret < 0) return ret;
+    ret = connFormatAddr(conn, addr, sizeof(addr), 1);
+    if (ret) {
+        conn->saddr = strdup(addr);
+    } else {
+        conn->saddr = NULL;
+    }
 
-    snprintf(fmtname, sizeof(fmtname), "%s-%s", laddr, raddr);
-    conn->fmtname = strdup(fmtname);
     return 0;
 }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -34,12 +34,18 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <sys/uio.h>
 
 #include "ae.h"
 
 #define CONN_INFO_LEN 32
 #define CONN_ADDR_STR_LEN 128 /* Similar to INET6_ADDRSTRLEN, hoping to handle other protocols. */
+
+#define NET_HOST_STR_LEN 256                          /* Longest valid hostname */
+#define NET_IP_STR_LEN 46                             /* INET6_ADDRSTRLEN is 46, but we need to be sure */
+#define NET_ADDR_STR_LEN (NET_IP_STR_LEN + 32)        /* Must be enough for ip:port */
+#define NET_HOST_PORT_STR_LEN (NET_HOST_STR_LEN + 32) /* Must be enough for hostname:port */
 
 struct aeEventLoop;
 typedef struct connection connection;
@@ -138,6 +144,7 @@ struct connection {
     ConnectionCallbackFunc conn_handler;
     ConnectionCallbackFunc write_handler;
     ConnectionCallbackFunc read_handler;
+    char *fmtname;
 };
 
 #define CONFIG_BINDADDR_MAX 16
@@ -266,6 +273,10 @@ static inline void connShutdown(connection *conn) {
 }
 
 static inline void connClose(connection *conn) {
+    if (conn->fmtname) {
+        free(conn->fmtname);
+        conn->fmtname = NULL;
+    }
     conn->type->close(conn);
 }
 
@@ -331,6 +342,23 @@ static inline int connAddrPeerName(connection *conn, char *ip, size_t ip_len, in
 
 static inline int connAddrSockName(connection *conn, char *ip, size_t ip_len, int *port) {
     return connAddr(conn, ip, ip_len, port, 0);
+}
+
+/* build a generic name for a connection of schema "LADDR:LPORT-RADDR:RPORT", except Unix socket */
+static inline int connFmtName(connection *conn) {
+    char fmtname[NET_ADDR_STR_LEN + NET_ADDR_STR_LEN + 2] = {0};
+    char laddr[NET_ADDR_STR_LEN], raddr[NET_ADDR_STR_LEN];
+    int ret;
+
+    ret = connFormatAddr(conn, laddr, sizeof(laddr), 0);
+    if (ret < 0) return ret;
+
+    ret = connFormatAddr(conn, raddr, sizeof(raddr), 1);
+    if (ret < 0) return ret;
+
+    snprintf(fmtname, sizeof(fmtname), "%s-%s", laddr, raddr);
+    conn->fmtname = strdup(fmtname);
+    return 0;
 }
 
 /* Test a connection is local or loopback.

--- a/src/db.c
+++ b/src/db.c
@@ -1828,6 +1828,7 @@ void deleteExpiredKeyAndPropagateWithDictIndex(serverDb *db, robj *keyobj, int d
     dbGenericDeleteWithDictIndex(db, keyobj, server.lazyfree_lazy_expire, DB_FLAG_KEY_EXPIRED, dict_index);
     latencyEndMonitor(expire_latency);
     latencyAddSampleIfNeeded("expire-del", expire_latency);
+    latencyTraceIfNeeded(db, "expire-del", expire_latency);
     notifyKeyspaceEvent(NOTIFY_EXPIRED, "expired", keyobj, db->id);
     signalModifiedKey(NULL, db, keyobj);
     propagateDeletion(db, keyobj, server.lazyfree_lazy_expire);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1216,7 +1216,7 @@ static long long activeDefragTimeProc(struct aeEventLoop *eventLoop, long long i
 
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("active-defrag-cycle", latency);
-
+    latencyTraceIfNeeded(db, "active-defrag-cycle", latency);
     if (haveMoreWork) {
         return computeDelayMs(endtime);
     } else {

--- a/src/evict.c
+++ b/src/evict.c
@@ -671,6 +671,7 @@ int performEvictions(void) {
             dbGenericDelete(db, keyobj, server.lazyfree_lazy_eviction, DB_FLAG_KEY_EVICTED);
             latencyEndMonitor(eviction_latency);
             latencyAddSampleIfNeeded("eviction-del", eviction_latency);
+            latencyTraceIfNeeded(db, "eviction-del", eviction_latency);
             delta -= (long long)zmalloc_used_memory();
             mem_freed += delta;
             server.stat_evictedkeys++;
@@ -734,10 +735,12 @@ cant_free:
         }
         latencyEndMonitor(lazyfree_latency);
         latencyAddSampleIfNeeded("eviction-lazyfree", lazyfree_latency);
+        latencyTraceIfNeeded(db, "eviction-lazyfree", lazyfree_latency);
     }
 
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("eviction-cycle", latency);
+    latencyTraceIfNeeded(db, "eviction-cycle", latency);
 
 update_metrics:
     if (result == EVICT_RUNNING || result == EVICT_FAIL) {

--- a/src/expire.c
+++ b/src/expire.c
@@ -359,7 +359,8 @@ void activeExpireCycle(int type) {
 
     elapsed = ustime() - start;
     server.stat_expire_cycle_time_used += elapsed;
-    latencyAddSampleIfNeeded("expire-cycle", elapsed / 1000);
+    latencyAddSampleIfNeeded("expire-cycle", elapsed);
+    latencyTraceIfNeeded(db, "expire-cycle", elapsed);
 
     /* Update our estimate of keys existing but yet to be expired.
      * Running average with this sample accounting for 5%. */

--- a/src/latency.c
+++ b/src/latency.c
@@ -70,6 +70,7 @@ int THPGetAnonHugePagesSize(void) {
  * having a fixed list to maintain. */
 void latencyMonitorInit(void) {
     server.latency_events = dictCreate(&latencyTimeSeriesDictType);
+    server.trace_events = sdsempty();
 }
 
 /* Add the specified sample to the specified time series "event".

--- a/src/latency.h
+++ b/src/latency.h
@@ -87,7 +87,7 @@ void latencyAddSample(const char *event, mstime_t latency);
 
 /* Add the sample only if the elapsed time is >= to the configured threshold. */
 #define latencyAddSampleIfNeeded(event, var) \
-    if (server.latency_monitor_threshold && ((var) / 1000) >= server.latency_monitor_threshold) latencyAddSample((event), ((var) / 1000));
+    if (server.latency_monitor_threshold && (var) >= server.latency_monitor_threshold * 1000) latencyAddSample((event), ((var) / 1000));
 
 /* Remove time from a nested event. */
 #define latencyRemoveNestedEvent(event_var, nested_var) event_var += nested_var;

--- a/src/latency.h
+++ b/src/latency.h
@@ -34,6 +34,8 @@
 #ifndef __LATENCY_H
 #define __LATENCY_H
 
+#include "trace/trace.h"
+
 #define LATENCY_TS_LEN 160 /* History length for every monitored event. */
 
 /* Representation of a latency sample: the sampling time and the latency
@@ -69,23 +71,23 @@ void latencyAddSample(const char *event, mstime_t latency);
 /* Latency monitoring macros. */
 
 /* Start monitoring an event. We just set the current time. */
-#define latencyStartMonitor(var)            \
-    if (server.latency_monitor_threshold) { \
-        var = mstime();                     \
-    } else {                                \
-        var = 0;                            \
+#define latencyStartMonitor(var)                                    \
+    if (server.latency_monitor_threshold || trace_events.enabled) { \
+        var = ustime();                                             \
+    } else {                                                        \
+        var = 0;                                                    \
     }
 
 /* End monitoring an event, compute the difference with the current time
  * to check the amount of time elapsed. */
-#define latencyEndMonitor(var)              \
-    if (server.latency_monitor_threshold) { \
-        var = mstime() - var;               \
+#define latencyEndMonitor(var)                                      \
+    if (server.latency_monitor_threshold || trace_events.enabled) { \
+        var = ustime() - var;                                       \
     }
 
 /* Add the sample only if the elapsed time is >= to the configured threshold. */
 #define latencyAddSampleIfNeeded(event, var) \
-    if (server.latency_monitor_threshold && (var) >= server.latency_monitor_threshold) latencyAddSample((event), (var));
+    if (server.latency_monitor_threshold && ((var) / 1000) >= server.latency_monitor_threshold) latencyAddSample((event), ((var) / 1000));
 
 /* Remove time from a nested event. */
 #define latencyRemoveNestedEvent(event_var, nested_var) event_var += nested_var;

--- a/src/module.c
+++ b/src/module.c
@@ -7711,7 +7711,8 @@ void VM__Assert(const char *estr, const char *file, int line) {
  * command. The call is skipped if the latency is smaller than the configured
  * latency-monitor-threshold. */
 void VM_LatencyAddSample(const char *event, mstime_t latency) {
-    latencyAddSampleIfNeeded(event, latency);
+    latencyAddSampleIfNeeded(event, latency * 1000);
+    latencyTraceIfNeeded(server, event, latency * 1000);
 }
 
 /* --------------------------------------------------------------------------

--- a/src/networking.c
+++ b/src/networking.c
@@ -1563,6 +1563,8 @@ void acceptCommonHandler(connection *conn, struct ClientFlags flags, char *ip) {
         freeClient(connGetPrivateData(conn));
         return;
     }
+
+    connFmtName(conn);
 }
 
 void freeClientOriginalArgv(client *c) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3475,6 +3475,7 @@ static void backgroundSaveDoneHandlerDisk(int exitcode, int bysignal, time_t sav
         rdbRemoveTempFile(server.child_pid, 0);
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("rdb-unlink-temp-file", latency);
+        latencyTraceIfNeeded(sys, "rdb-unlink-temp-file", latency);
         /* SIGUSR1 is whitelisted, so we have a way to kill a child without
          * triggering an error condition. */
         if (bysignal != SIGUSR1) server.lastbgsave_status = C_ERR;

--- a/src/server.c
+++ b/src/server.c
@@ -2794,6 +2794,7 @@ void initServer(void) {
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;
+    server.trace_events = 0;
     resetReplicationBuffer();
 
     /* Make sure the locale is set on startup based on the config file. */
@@ -3746,7 +3747,7 @@ void call(client *c, int flags) {
         duration = ustime() - call_timer;
 
     if (trace_events.commands) {
-        valkey_commands_trace(valkey_commands, command_call, connGetType(c->conn), c->conn->fmtname, real_cmd->declared_name, duration);
+        valkey_commands_trace(valkey_commands, command_call, connGetType(c->conn), c->conn->saddr, c->conn->daddr, real_cmd->declared_name, duration);
     }
     c->duration += duration;
     dirty = server.dirty - dirty;

--- a/src/server.c
+++ b/src/server.c
@@ -52,6 +52,8 @@
 #include "lua/debug_lua.h"
 #include "eval.h"
 
+#include "trace/trace_commands.h"
+
 #include <time.h>
 #include <signal.h>
 #include <sys/wait.h>
@@ -1734,6 +1736,7 @@ void whileBlockedCron(void) {
 
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("while-blocked-cron", latency);
+    latencyTraceIfNeeded(server, "while-blocked-cron", latency);
 
     /* We received a SIGTERM during loading, shutting down here in a safe way,
      * as it isn't ok doing so inside the signal handler. */
@@ -1876,7 +1879,9 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     if (server.aof_state == AOF_ON || server.aof_state == AOF_WAIT_REWRITE) flushAppendOnlyFile(0);
 
     /* Record time consumption of AOF writing. */
-    durationAddSample(EL_DURATION_TYPE_AOF, getMonotonicUs() - aof_start_time);
+    monotime aof_duration = getMonotonicUs() - aof_start_time;
+    durationAddSample(EL_DURATION_TYPE_AOF, aof_duration);
+    latencyTraceIfNeeded(aof, "aof-flush", aof_duration);
 
     /* Update the fsynced replica offset.
      * If an initial rewrite is in progress then not all data is guaranteed to have actually been
@@ -1920,9 +1925,11 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     if (server.el_start > 0) {
         monotime el_duration = getMonotonicUs() - server.el_start;
         durationAddSample(EL_DURATION_TYPE_EL, el_duration);
+        latencyTraceIfNeeded(server, "eventloop", el_duration);
     }
     server.el_cron_duration += duration_before_aof + duration_after_write;
     durationAddSample(EL_DURATION_TYPE_CRON, server.el_cron_duration);
+    latencyTraceIfNeeded(server, "eventloop-cron", server.el_cron_duration);
     server.el_cron_duration = 0;
     /* Record max command count per cycle. */
     if (server.stat_numcommands > server.el_cmd_cnt_start) {
@@ -1964,6 +1971,7 @@ void afterSleep(struct aeEventLoop *eventLoop, int numevents) {
             moduleFireServerEvent(VALKEYMODULE_EVENT_EVENTLOOP, VALKEYMODULE_SUBEVENT_EVENTLOOP_AFTER_SLEEP, NULL);
             latencyEndMonitor(latency);
             latencyAddSampleIfNeeded("module-acquire-GIL", latency);
+            latencyTraceIfNeeded(server, "module-acquire-GIL", latency);
         }
         /* Set the eventloop start time. */
         server.el_start = getMonotonicUs();
@@ -3737,6 +3745,9 @@ void call(client *c, int flags) {
     else
         duration = ustime() - call_timer;
 
+    if (trace_events.commands) {
+        valkey_commands_trace(valkey_commands, command_call, connGetType(c->conn), c->conn->fmtname, real_cmd->declared_name, duration);
+    }
     c->duration += duration;
     dirty = server.dirty - dirty;
     if (dirty < 0) dirty = 0;
@@ -3767,7 +3778,8 @@ void call(client *c, int flags) {
      * a MULTI-EXEC from inside an AOF). */
     if (update_command_stats) {
         char *latency_event = (real_cmd->flags & CMD_FAST) ? "fast-command" : "command";
-        latencyAddSampleIfNeeded(latency_event, duration / 1000);
+        latencyAddSampleIfNeeded(latency_event, duration);
+        latencyTraceIfNeeded(server, latency_event, duration);
         if (server.execution_nesting == 0) durationAddSample(EL_DURATION_TYPE_CMD, duration);
     }
 
@@ -6563,7 +6575,8 @@ int serverFork(int purpose) {
         server.stat_fork_time = ustime() - start;
         server.stat_fork_rate =
             (double)zmalloc_used_memory() * 1000000 / server.stat_fork_time / (1024 * 1024 * 1024); /* GB per second. */
-        latencyAddSampleIfNeeded("fork", server.stat_fork_time / 1000);
+        latencyAddSampleIfNeeded("fork", server.stat_fork_time);
+        latencyTraceIfNeeded(sys, "fork", server.stat_fork_time);
 
         /* The child_pid and child_type are only for mutually exclusive children.
          * other child types should handle and store their pid's in dedicated variables.

--- a/src/server.h
+++ b/src/server.h
@@ -81,6 +81,7 @@ typedef long long ustime_t; /* microsecond time type. */
 #include "rax.h"        /* Radix tree */
 #include "connection.h" /* Connection abstraction */
 #include "memory_prefetch.h"
+#include "trace/trace.h"
 
 #define dismissMemory zmadvise_dontneed
 
@@ -136,10 +137,6 @@ struct hdr_histogram;
 #define CONFIG_DEFAULT_PID_FILE "/var/run/valkey.pid"
 #define CONFIG_DEFAULT_BINDADDR_COUNT 2
 #define CONFIG_DEFAULT_BINDADDR {"*", "-::*"}
-#define NET_HOST_STR_LEN 256                          /* Longest valid hostname */
-#define NET_IP_STR_LEN 46                             /* INET6_ADDRSTRLEN is 46, but we need to be sure */
-#define NET_ADDR_STR_LEN (NET_IP_STR_LEN + 32)        /* Must be enough for ip:port */
-#define NET_HOST_PORT_STR_LEN (NET_HOST_STR_LEN + 32) /* Must be enough for hostname:port */
 #define CONFIG_BINDADDR_MAX 16
 #define CONFIG_MIN_RESERVED_FDS 32
 #define CONFIG_DEFAULT_PROC_TITLE_TEMPLATE "{title} {listen-addr} {server-mode}"
@@ -2113,6 +2110,7 @@ struct valkeyServer {
     /* Latency monitor */
     long long latency_monitor_threshold;
     dict *latency_events;
+    sds trace_events;
     /* ACLs */
     char *acl_filename;           /* ACL Users file. NULL if not configured. */
     unsigned long acllog_max_len; /* Maximum length of the ACL LOG list. */

--- a/src/serverassert.h
+++ b/src/serverassert.h
@@ -53,6 +53,10 @@
 #define likely(x) (x)
 #endif
 
+#ifdef assert
+#undef assert
+#endif
+
 #define assert(_e) (likely((_e)) ? (void)0 : (_serverAssert(#_e, __FILE__, __LINE__), valkey_unreachable()))
 #define panic(...) _serverPanic(__FILE__, __LINE__, __VA_ARGS__), valkey_unreachable()
 

--- a/src/trace/README.md
+++ b/src/trace/README.md
@@ -22,7 +22,7 @@ Enable lttng trace events dynamically:
 ```
 ~# lttng destroy valkey
 ~# lttng create valkey
-~# lttng enable-event -u "valkey*"
+~# lttng enable-event -u 'valkey*'
 ~# lttng track -u -p `pidof valkey-server`
 ~# lttng start
 ~# lttng stop
@@ -64,6 +64,7 @@ Generally valkey-server would not run in full utilization, the overhead is accep
 
 | event                    | provider |
 | -------------------------- | ---------- |
+| command-call             | commands  |
 | rdb-unlink-temp-file     | sys      |
 | fork                     | sys      |
 | command-unblocking       | server   |
@@ -88,5 +89,4 @@ Generally valkey-server would not run in full utilization, the overhead is accep
 | aof-write                | aof      |
 | aof-fsync-always         | aof      |
 | aof-fstat                | aof      |
-| aof-rename               | aof      |
 | aof-rename               | aof      |

--- a/src/trace/README.md
+++ b/src/trace/README.md
@@ -1,0 +1,92 @@
+## Introduction
+
+This directory contains the implementation of tracing using [LTTng](https://lttng.org/) (Linux Trace Toolkit Next Generation).
+
+## LTTng Installation
+
+To install LTTng on your Linux system, follow the instructions provided in the [LTTng documentation](https://lttng.org/download/)
+
+> Dependency LTTNG version is greater than 2.12.
+
+## LTTng QuickStart
+
+LTTng is an open source tracing framework for Linux that provides highly efficient and low-overhead tracing capabilities. It allows developers to trace both kernel and user-space applications.
+
+Building Valkey with LTTng support:
+
+```
+USE_LTTNG=yes make
+```
+
+Enable lttng trace events dynamically:
+```
+~# lttng destroy valkey
+~# lttng create valkey
+~# lttng enable-event -u "valkey*"
+~# lttng track -u -p `pidof valkey-server`
+~# lttng start
+~# lttng stop
+~# lttng view
+```
+
+Examples (a client run 'SET', another run 'keys'):
+```
+...
+[15:30:19.334463706] (+0.000001243) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+[15:30:19.334465183] (+0.000001477) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
+[15:30:19.334466516] (+0.000001333) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+[15:30:19.334467738] (+0.000001222) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+[15:30:19.334469105] (+0.000001367) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
+[15:30:19.334470327] (+0.000001222) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+[15:30:19.369348485] (+0.034878158) libai valkey:command_call: { cpu_id = 15 }, { name = "keys", duration = 34874 }
+[15:30:19.369698322] (+0.000349837) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 4 }
+[15:30:19.369702327] (+0.000004005) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 2 }
+[15:30:19.369704098] (+0.000001771) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
+[15:30:19.369705884] (+0.000001786) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+[15:30:19.369707501] (+0.000001617) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
+[15:30:19.369708743] (+0.000001242) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+[15:30:19.369710052] (+0.000001309) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
+[15:30:19.369711619] (+0.000001567) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+...
+```
+
+Then we can use another script to analyze topN slow commands and other system
+level events.
+
+About performance overhead (valkey-benchmark -t get -n 1000000 --threads 4):
+1> no lttng builtin: 285632.69 requests per second
+2> lttng builtin, no trace: 285551.09 requests per second (almost 0 overhead)
+3> lttng builtin, trace commands: 266595.59 requests per second (about ~6.6 overhead)
+
+Generally valkey-server would not run in full utilization, the overhead is acceptable.
+
+## Supported Events
+
+| event                    | provider |
+| -------------------------- | ---------- |
+| rdb-unlink-temp-file     | sys      |
+| fork                     | sys      |
+| command-unblocking       | server   |
+| while-blocked-cron       | server   |
+| module-acquire-GIL       | server   |
+| expire-del               | db       |
+| active-defrag-cycle      | db       |
+| eviction-del             | db       |
+| eviction-lazyfree        | db       |
+| eviction-cycle           | db       |
+| expire-cycle             | db       |
+| cluster-config-open      | cluster  |
+| cluster-config-write     | cluster  |
+| cluster-config-fsync     | cluster  |
+| cluster-config-rename    | cluster  |
+| cluster-config-dir-fsync | cluster  |
+| cluster-config-close     | cluster  |
+| cluster-config-unlink    | cluster  |
+| aof-write-pending-fsync  | aof      |
+| aof-write-active-child   | aof      |
+| aof-write-alone          | aof      |
+| aof-write                | aof      |
+| aof-fsync-always         | aof      |
+| aof-fstat                | aof      |
+| aof-rename               | aof      |
+| aof-rename               | aof      |

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -1,0 +1,19 @@
+/* ==========================================================================
+ * trace.c - support generic tracing layers.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "trace.h"
+
+struct valkeyTraceEvents trace_events = {0};

--- a/src/trace/trace.h
+++ b/src/trace/trace.h
@@ -1,0 +1,50 @@
+/* ==========================================================================
+ * trace.h - support generic tracing layers.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#if !defined(__VALKEY_TRACE_H__)
+#define __VALKEY_TRACE_H__
+
+#include "trace_db.h"
+#include "trace_cluster.h"
+#include "trace_sys.h"
+#include "trace_aof.h"
+#include "trace_server.h"
+#include "trace_commands.h"
+
+typedef struct valkeyTraceEvents {
+    union {
+        unsigned aof : 1;
+        unsigned server : 1;
+        unsigned cluster : 1;
+        unsigned sys : 1;
+        unsigned db : 1;
+        unsigned commands : 1;
+    };
+    unsigned enabled;
+} valkeyTraceEvents;
+
+extern struct valkeyTraceEvents trace_events;
+
+#ifdef USE_LTTNG
+#define latencyTraceIfNeeded(type, event, var) \
+    if (trace_events.type) valkey_##type##_trace(valkey_##type, latency, (event), (var));
+#else
+#define latencyTraceIfNeeded(type, event, var) \
+    do {                                       \
+    } while (0)
+#endif
+
+#endif /* __VALKEY_TRACE_H__ */

--- a/src/trace/trace_aof.c
+++ b/src/trace/trace_aof.c
@@ -1,0 +1,20 @@
+/* ==========================================================================
+ * trace_aof.c - support lttng tracing for aof events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "trace_aof.h"

--- a/src/trace/trace_aof.h
+++ b/src/trace/trace_aof.h
@@ -1,0 +1,71 @@
+/* ==========================================================================
+ * trace_aof.h - support lttng tracing for aof events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifdef USE_LTTNG
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER valkey_aof
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_aof.h"
+
+#if !defined(__VALKEY_TRACE_AOF_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __VALKEY_TRACE_AOF_H__
+
+#include <lttng/tracepoint.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	valkey_aof,
+
+	/* Tracepoint name */
+	latency,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		const char *, event,
+		uint64_t, duration
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(event, event)
+		lttng_ust_field_integer(uint64_t, duration, duration)
+	)
+)
+
+#define valkey_aof_trace(...) lttng_ust_tracepoint(__VA_ARGS__)
+
+#endif /* __VALKEY_TRACE_AOF_H__ */
+
+#include <lttng/tracepoint-event.h>
+
+#else /* USE_LTTNG */
+
+#ifndef __VALKEY_TRACE_AOF_H__
+#define __VALKEY_TRACE_AOF_H__
+
+/* avoid compiler warning on empty source file */
+static inline void __valkey_aof_trace(void) {
+}
+
+#define valkey_aof_trace(...) \
+    do {                     \
+    } while (0)
+
+#endif /* __VALKEY_TRACE_AOF_H__ */
+
+#endif /* USE_LTTNG */

--- a/src/trace/trace_cluster.c
+++ b/src/trace/trace_cluster.c
@@ -1,0 +1,20 @@
+/* ==========================================================================
+ * trace_cluster.c - support lttng tracing for cluster events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "trace_cluster.h"

--- a/src/trace/trace_cluster.h
+++ b/src/trace/trace_cluster.h
@@ -1,0 +1,71 @@
+/* ==========================================================================
+ * trace_cluster.h - support lttng tracing for cluster events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifdef USE_LTTNG
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER valkey_cluster
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_cluster.h"
+
+#if !defined(__VALKEY_TRACE_CLUSTER_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __VALKEY_TRACE_CLUSTER_H__
+
+#include <lttng/tracepoint.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	valkey_cluster,
+
+	/* Tracepoint name */
+	latency,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		const char *, event,
+		uint64_t, duration
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(event, event)
+		lttng_ust_field_integer(uint64_t, duration, duration)
+	)
+)
+
+#define valkey_cluster_trace(...) lttng_ust_tracepoint(__VA_ARGS__)
+
+#endif /* __VALKEY_TRACE_CLUSTER_H__ */
+
+#include <lttng/tracepoint-event.h>
+
+#else /* USE_LTTNG */
+
+#ifndef __VALKEY_TRACE_CLUSTER_H__
+#define __VALKEY_TRACE_CLUSTER_H__
+
+/* avoid compiler warning on empty source file */
+static inline void __valkey_cluster_trace(void) {
+}
+
+#define valkey_cluster_trace(...) \
+    do {                     \
+    } while (0)
+
+#endif /* __VALKEY_TRACE_CLUSTER_H__ */
+
+#endif /* USE_LTTNG */

--- a/src/trace/trace_commands.c
+++ b/src/trace/trace_commands.c
@@ -1,0 +1,20 @@
+/* ==========================================================================
+ * trace_commands.c - support lttng tracing for commands events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "trace_commands.h"

--- a/src/trace/trace_commands.h
+++ b/src/trace/trace_commands.h
@@ -37,7 +37,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
 	/* Input arguments */
 	LTTNG_UST_TP_ARGS(
 		const char *, prot,
-		const char *, conn,
+		const char *, saddr,
+		const char *, daddr,
 		const char *, name,
 		uint64_t, duration
 	),
@@ -45,7 +46,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
 	/* Output event fields */
 	LTTNG_UST_TP_FIELDS(
 		lttng_ust_field_string(prot, prot)
-		lttng_ust_field_string(conn, conn)
+		lttng_ust_field_string(saddr, saddr)
+		lttng_ust_field_string(daddr, daddr)
 		lttng_ust_field_string(name, name)
 		lttng_ust_field_integer(uint64_t, duration, duration)
 	)

--- a/src/trace/trace_commands.h
+++ b/src/trace/trace_commands.h
@@ -1,0 +1,75 @@
+/* ==========================================================================
+ * trace_commands.h - support lttng tracing for commands events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifdef USE_LTTNG
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER valkey_commands
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_commands.h"
+
+#if !defined(__VALKEY_TRACE_COMMANDS_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __VALKEY_TRACE_COMMANDS_H__
+
+#include <lttng/tracepoint.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	valkey_commands,
+
+	/* Tracepoint name */
+	command_call,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		const char *, prot,
+		const char *, conn,
+		const char *, name,
+		uint64_t, duration
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(prot, prot)
+		lttng_ust_field_string(conn, conn)
+		lttng_ust_field_string(name, name)
+		lttng_ust_field_integer(uint64_t, duration, duration)
+	)
+)
+
+#define valkey_commands_trace(...) lttng_ust_tracepoint(__VA_ARGS__)
+
+#endif /* __VALKEY_TRACE_COMMANDS_H__ */
+
+#include <lttng/tracepoint-event.h>
+
+#else /* USE_LTTNG */
+
+#ifndef __VALKEY_TRACE_COMMANDS_H__
+#define __VALKEY_TRACE_COMMANDS_H__
+
+/* avoid compiler warning on empty source file */
+static inline void __valkey_commands_trace(void) {
+}
+
+#define valkey_commands_trace(...) \
+    do {                           \
+    } while (0)
+
+#endif /* __VALKEY_TRACE_COMMANDS_H__ */
+
+#endif /* USE_LTTNG */

--- a/src/trace/trace_db.c
+++ b/src/trace/trace_db.c
@@ -1,0 +1,20 @@
+/* ==========================================================================
+ * trace_db.c - support lttng tracing for db events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "trace_db.h"

--- a/src/trace/trace_db.h
+++ b/src/trace/trace_db.h
@@ -1,0 +1,71 @@
+/* ==========================================================================
+ * trace_db.h - support lttng tracing for db events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifdef USE_LTTNG
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER valkey_db
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_db.h"
+
+#if !defined(__VALKEY_TRACE_DB_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __VALKEY_TRACE_DB_H__
+
+#include <lttng/tracepoint.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	valkey_db,
+
+	/* Tracepoint name */
+	latency,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		const char *, event,
+		uint64_t, duration
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(event, event)
+		lttng_ust_field_integer(uint64_t, duration, duration)
+	)
+)
+
+#define valkey_db_trace(...) lttng_ust_tracepoint(__VA_ARGS__)
+
+#endif /* __VALKEY_TRACE_DB_H__ */
+
+#include <lttng/tracepoint-event.h>
+
+#else /* USE_LTTNG */
+
+#ifndef __VALKEY_TRACE_DB_H__
+#define __VALKEY_TRACE_DB_H__
+
+/* avoid compiler warning on empty source file */
+static inline void __valkey_db_trace(void) {
+}
+
+#define valkey_db_trace(...) \
+    do {                     \
+    } while (0)
+
+#endif /* __VALKEY_TRACE_DB_H__ */
+
+#endif /* USE_LTTNG */

--- a/src/trace/trace_server.c
+++ b/src/trace/trace_server.c
@@ -1,0 +1,20 @@
+/* ==========================================================================
+ * trace_server.c - support lttng tracing for server events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "trace_server.h"

--- a/src/trace/trace_server.h
+++ b/src/trace/trace_server.h
@@ -1,0 +1,71 @@
+/* ==========================================================================
+ * trace_server.h - support lttng tracing for server events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifdef USE_LTTNG
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER valkey_server
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_server.h"
+
+#if !defined(__VALKEY_TRACE_SERVER_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __VALKEY_TRACE_SERVER_H__
+
+#include <lttng/tracepoint.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	valkey_server,
+
+	/* Tracepoint name */
+	latency,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		const char *, event,
+		uint64_t, duration
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(event, event)
+		lttng_ust_field_integer(uint64_t, duration, duration)
+	)
+)
+
+#define valkey_server_trace(...) lttng_ust_tracepoint(__VA_ARGS__)
+
+#endif /* __VALKEY_TRACE_SERVER_H__ */
+
+#include <lttng/tracepoint-event.h>
+
+#else /* USE_LTTNG */
+
+#ifndef __VALKEY_TRACE_SERVER_H__
+#define __VALKEY_TRACE_SERVER_H__
+
+/* avoid compiler warning on empty source file */
+static inline void __valkey_server_trace(void) {
+}
+
+#define valkey_server_trace(...) \
+    do {                     \
+    } while (0)
+
+#endif /* __VALKEY_TRACE_SERVER_H__ */
+
+#endif /* USE_LTTNG */

--- a/src/trace/trace_sys.c
+++ b/src/trace/trace_sys.c
@@ -1,0 +1,20 @@
+/* ==========================================================================
+ * trace_sys.c - support lttng tracing for system events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "trace_sys.h"

--- a/src/trace/trace_sys.h
+++ b/src/trace/trace_sys.h
@@ -1,0 +1,71 @@
+/* ==========================================================================
+ * trace_sys.h - support lttng tracing for system events.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2025  zhenwei pi <pizhenwei@bytedance.com>
+ * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
+ *
+ * This work is licensed under BSD 3-Clause, License 1 of the COPYING file in
+ * the top-level directory.
+ * ==========================================================================
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifdef USE_LTTNG
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER valkey_sys
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_sys.h"
+
+#if !defined(__VALKEY_TRACE_SYS_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __VALKEY_TRACE_SYS_H__
+
+#include <lttng/tracepoint.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	valkey_sys,
+
+	/* Tracepoint name */
+	latency,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		const char *, event,
+		uint64_t, duration
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(event, event)
+		lttng_ust_field_integer(uint64_t, duration, duration)
+	)
+)
+
+#define valkey_sys_trace(...) lttng_ust_tracepoint(__VA_ARGS__)
+
+#endif /* __VALKEY_TRACE_SYS_H__ */
+
+#include <lttng/tracepoint-event.h>
+
+#else /* USE_LTTNG */
+
+#ifndef __VALKEY_TRACE_SYS_H__
+#define __VALKEY_TRACE_SYS_H__
+
+/* avoid compiler warning on empty source file */
+static inline void __valkey_sys_trace(void) {
+}
+
+#define valkey_sys_trace(...) \
+    do {                     \
+    } while (0)
+
+#endif /* __VALKEY_TRACE_SYS_H__ */
+
+#endif /* USE_LTTNG */

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -193,6 +193,16 @@ tags {"needs:debug"} {
         catch {r LATENCY help xxx} e
         assert_match "*wrong number of arguments for 'latency|help' command" $e
     }
+
+    test {LATENCY trace events configuration} {
+        r config set trace-events ""
+        r config set trace-events "aof server cluster sys db commands"
+        assert_equal [lindex [r config get trace-events] 1] "aof server cluster sys db commands"
+        catch {r config set trace-events "test"} e
+        assert_match "*trace events should between*" $e
+        r config set trace-events ""
+        assert_equal [lindex [r config get trace-events] 1] ""
+    }
 }
 
 start_cluster 1 1 {tags {"latency-monitor cluster external:skip needs:latency"} overrides {latency-monitor-threshold 1}} {


### PR DESCRIPTION
## Introduce

In a production environment, it's quite challenging to figure out why a Valkey is under high load. Right now, tools like INFO or slowlog can offer some clues. But if the Valkey can't respond, we might not get any information at all. 
Usually, we have to rely on tools like `strace` or `perf` to find the root cause. If we set up trace points in advance during the project development, we can quickly pinpoint performance issues.

In this current PR, support has been added for all latency sampling points. Also, information reporting for command execution has been added. At the same time, it supports dynamically turning on or off the information reporting as required. The trace feature is implemented based on LTTng, and this capability is supported in projects like QEMU, Ceph. 

## How to use

Building Valkey with LTTng support:

```
USE_LTTNG=yes make
```

Open event report：
```
config set trace-events "sys server db cluster aof commands"
```

Events are classified as follows：
- sys (System-level operations)
- server (Server core logic)
- db (Database core operations)
- cluster (Cluster configuration operations)
- aof (AOF persistence operations)
- commands（Command execution information）

## How to trace

Enable lttng trace events dynamically:
```
~# lttng destroy valkey
~# lttng create valkey
~# lttng enable-event -u valkey:*
~# lttng track -u -p `pidof valkey-server`
~# lttng start
~# lttng stop
~# lttng view
```

Examples (a client run 'SET', another run 'keys'):

```
[15:30:19.334463706] (+0.000001243) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
[15:30:19.334465183] (+0.000001477) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
[15:30:19.334466516] (+0.000001333) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
[15:30:19.334467738] (+0.000001222) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
[15:30:19.334469105] (+0.000001367) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
[15:30:19.334470327] (+0.000001222) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
[15:30:19.369348485] (+0.034878158) libai valkey:command_call: { cpu_id = 15 }, { name = "keys", duration = 34874 }
[15:30:19.369698322] (+0.000349837) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 4 }
[15:30:19.369702327] (+0.000004005) libai valkey:command_call: { cpu_id = 15 }, { name = "set", duration = 2 }

```

Then we can use another script to analyze topN slow commands and other system
level events.

About performance overhead (valkey-benchmark -t get -n 1000000 --threads 4):
1> no lttng builtin: 285632.69 requests per second
2> lttng builtin, no trace: 285551.09 requests per second (almost 0 overhead)
3> lttng builtin, trace commands: 266595.59 requests per second (about ~6.6 overhead)

Generally valkey-server would not run in full utilization, the overhead is acceptable.

## Problem analysis

Add prot and conn field into trace command

Run benchmark tool:
```
GET: rps=227428.0 (overall: 222756.2) avg_msec=0.114 (overall: 0.117)
GET: rps=225248.0 (overall: 223005.2) avg_msec=0.115 (overall: 0.117)
GET: rps=167474.1 (overall: 217942.2) avg_msec=0.193 (overall: 0.122) --> performance drop
GET: rps=220192.0 (overall: 218129.5) avg_msec=0.118 (overall: 0.122)
GET: rps=222868.0 (overall: 218493.7) avg_msec=0.117 (overall: 0.121)

```
Run another 'keys *' command in another connection, lead benchmark performance
drop.

At the same time, lttng traces events:
```
[21:16:30.420997167] (+0.000004064) zhenwei valkey:command_call: { cpu_id = 6 }, { prot = "tcp", conn = "127.0.0.1:6379-127.0.0.1:54668", name = "get", duration = 1 }
[21:16:30.421001262] (+0.000004095) zhenwei valkey:command_call: { cpu_id = 6 }, { prot = "tcp", conn = "127.0.0.1:6379-127.0.0.1:54782", name = "get", duration = 1 }
[21:16:30.485562459] (+0.064561197) zhenwei valkey:command_call: { cpu_id = 6 }, { prot = "tcp", conn = "127.0.0.1:6379-127.0.0.1:54386", name = "keys", duration = 64551 } --> root cause
[21:16:30.485583101] (+0.000020642) zhenwei valkey:command_call: { cpu_id = 6 }, { prot = "tcp", conn = "127.0.0.1:6379-127.0.0.1:54522", name = "get", duration = 1 }
[21:16:30.485763891] (+0.000180790) zhenwei valkey:command_call: { cpu_id = 6 }, { prot = "tcp", conn = "127.0.0.1:6379-127.0.0.1:54542", name = "get", duration = 1 }
[21:16:30.485766451] (+0.000002560) zhenwei valkey:command_call: { cpu_id = 6 }, { prot = "tcp", conn = "127.0.0.1:6379-127.0.0.1:54438", name = "get", duration = 1 }
```

From this change, we can see that connection 127.0.0.1:6379-127.0.0.1:54386
affects other connections.